### PR TITLE
Backtrace hyperlinks and tweaks.

### DIFF
--- a/airbrake.go
+++ b/airbrake.go
@@ -32,6 +32,13 @@ var (
 	// This feature also requires the APP to have its Repository configured in errbit.
 	RootPackage = ""
 
+	// AppVersion determines which commit will be used for backtrace hyperlinks.
+	// If unset, errbit defaults to `master`. For github it should be a branch name
+	// or a commit hash.
+	// One way to record the corresponding commit hash in a compiled binary
+	// is to use the -X linker flag. (see https://golang.org/cmd/ld)
+	AppVersion = ""
+
 	sensitive     = regexp.MustCompile(`password|token|secret|key`)
 	badResponse   = errors.New("Bad response")
 	apiKeyMissing = errors.New("Please set the airbrake.ApiKey before doing calls")
@@ -189,12 +196,19 @@ func params(e error, request *http.Request) map[string]interface{} {
 	// Compile header parameters.
 	header := make(map[string]string)
 	req["Header"] = header
-	header["Method"] = request.Method
-	header["Protocol"] = request.Proto
+	header["REQUEST_METHOD"] = request.Method
+	header["REQUEST_PROTOCOL"] = request.Proto
 	for k, v := range request.Header {
 		if !omit(k, v) {
-			header[k] = v[0]
+			// errbit processes some entries, e.g. user agent, and expects
+			// the keys to be uppercased, underscored and prefixed with HTTP_
+			k := strings.ToUpper(strings.Replace(k, "-", "_", -1))
+			header["HTTP_"+k] = v[0]
 		}
+	}
+	// This allows errbit to hyperlink to specific commit in the app repo.
+	if AppVersion != "" {
+		header["APP_VERSION"] = AppVersion
 	}
 
 	// Compile query/form parameters.

--- a/airbrake.go
+++ b/airbrake.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"strings"
 	"text/template"
 )
 
@@ -24,12 +25,16 @@ var (
 	// The param keys will be rendered as "?<param>" so they will sort together at the top of the tab.
 	PrettyParams = false
 
+	// RootPackage enables rendering of the backtrace with hyperlinks to the repository.
+	// If set to the name of the root package of the project, e.g. github.com/user/project,
+	// any file paths in the backtrace that contain that string will be converted
+	// to the `[PROJECT_ROOT]/...` form, which triggers the hyperlinking in errbit.
+	// This feature also requires the APP to have its Repository configured in errbit.
+	RootPackage = ""
+
 	sensitive     = regexp.MustCompile(`password|token|secret|key`)
 	badResponse   = errors.New("Bad response")
 	apiKeyMissing = errors.New("Please set the airbrake.ApiKey before doing calls")
-	dunno         = []byte("???")
-	centerDot     = []byte("·")
-	dot           = []byte(".")
 	tmpl          = template.Must(template.New("error").Parse(source))
 )
 
@@ -47,7 +52,7 @@ func stacktrace(skip int) (lines []Line) {
 			break
 		}
 
-		item := Line{string(function(pc)), string(file), line}
+		item := Line{function(pc), locate(file), line}
 
 		// ignore panic method
 		if item.Function != "panic" {
@@ -58,23 +63,39 @@ func stacktrace(skip int) (lines []Line) {
 }
 
 // function returns, if possible, the name of the function containing the PC.
-func function(pc uintptr) []byte {
+func function(pc uintptr) string {
 	fn := runtime.FuncForPC(pc)
 	if fn == nil {
-		return dunno
+		return "???"
+	} else {
+		return shorten(fn.Name())
 	}
-	name := []byte(fn.Name())
+}
+
+func shorten(name string) string {
 	// The name includes the path name to the package, which is unnecessary
 	// since the file name is already included.  Plus, it has center dots.
 	// That is, we see
 	//  runtime/debug.*T·ptrmethod
 	// and want
-	//  *T.ptrmethod
-	if period := bytes.Index(name, dot); period >= 0 {
+	//  debug.*T.ptrmethod
+	if period := strings.LastIndex(name, "/"); period >= 0 {
 		name = name[period+1:]
 	}
-	name = bytes.Replace(name, centerDot, dot, -1)
+	name = strings.Replace(name, "·", ".", -1)
 	return name
+}
+
+func locate(f string) string {
+	if RootPackage == "" {
+		return f
+	}
+	parts := strings.Split(f, RootPackage)
+	if len(parts) == 2 {
+		return "[PROJECT_ROOT]" + parts[1]
+	} else {
+		return f
+	}
 }
 
 func post(params map[string]interface{}) error {

--- a/airbrake.go
+++ b/airbrake.go
@@ -39,7 +39,7 @@ var (
 	// is to use the -X linker flag. (see https://golang.org/cmd/ld)
 	AppVersion = ""
 
-	sensitive     = regexp.MustCompile(`password|token|secret|key`)
+	sensitive     = regexp.MustCompile(`(?i)password|token|secret|key`)
 	badResponse   = errors.New("Bad response")
 	apiKeyMissing = errors.New("Please set the airbrake.ApiKey before doing calls")
 	tmpl          = template.Must(template.New("error").Parse(source))

--- a/airbrake_test.go
+++ b/airbrake_test.go
@@ -64,7 +64,7 @@ func TestShorten(t *testing.T) {
 		{"github.com/Shopify/reportifydb.*Handler.AdminQuery·fm", "reportifydb.*Handler.AdminQuery.fm"},
 	} {
 		if result := shorten(sample.in); result != sample.out {
-			t.Fatalf("expected: %s got: %s", sample.out, result)
+			t.Errorf("expected: %s got: %s", sample.out, result)
 		}
 	}
 }
@@ -86,7 +86,7 @@ func TestLocate(t *testing.T) {
 		},
 	} {
 		if result := locate(sample.in); result != sample.out {
-			t.Fatalf("expected: %s got: %s", sample.out, result)
+			t.Errorf("expected: %s got: %s", sample.out, result)
 		}
 	}
 }
@@ -94,7 +94,7 @@ func TestLocate(t *testing.T) {
 // Make sure we match https://help.airbrake.io/kb/api-2/notifier-api-version-23
 func TestTemplateV2(t *testing.T) {
 	var p map[string]interface{}
-	request, _ := http.NewRequest("GET", "/query?t=xxx&q=SHOW+x+BY+y+FROM+z&key=sesame&timezone=", nil)
+	request, _ := http.NewRequest("GET", "/query?t=xxx&q=SHOW+x+BY+y+FROM+z&kEy=sesame&timezone=", nil)
 	request.Header.Set("Host", "Zulu")
 	request.Header.Set("Keep_Secret", "Sesame")
 	PrettyParams = true
@@ -126,7 +126,7 @@ func TestTemplateV2(t *testing.T) {
 	// Render the params.
 	var b bytes.Buffer
 	if err := tmpl.Execute(&b, p); err != nil {
-		t.Fatalf("Template error: %s", err)
+		t.Errorf("Template error: %s", err)
 	}
 
 	// Validate the <error> node.
@@ -135,13 +135,13 @@ func TestTemplateV2(t *testing.T) {
     <class>*errors.errorString</class>
     <message>Boom!</message>
     <backtrace>` {
-		t.Fatal(chunk)
+		t.Error(chunk)
 	}
 
 	// Validate the <request> node.
 	chunk = regexp.MustCompile(`(?s)<request>.*</request>`).FindString(b.String())
 	if chunk != `<request>
-    <url>/query?t=xxx&amp;q=SHOW+x+BY+y+FROM+z&amp;key=sesame&amp;timezone=</url>
+    <url>/query?t=xxx&amp;q=SHOW+x+BY+y+FROM+z&amp;kEy=sesame&amp;timezone=</url>
     <component></component>
     <action></action>
     <params>
@@ -156,6 +156,6 @@ func TestTemplateV2(t *testing.T) {
       <var key="REQUEST_PROTOCOL">HTTP/1.1</var>
     </cgi-data>
   </request>` {
-		t.Fatal(chunk)
+		t.Error(chunk)
 	}
 }

--- a/airbrake_test.go
+++ b/airbrake_test.go
@@ -55,6 +55,42 @@ func TestNotify(t *testing.T) {
 	time.Sleep(1e9)
 }
 
+func TestShorten(t *testing.T) {
+	for _, sample := range []struct{ in, out string }{
+		{"net/http.func·011", "http.func.011"},
+		{"runtime.panic", "runtime.panic"},
+		{"github.com/tobi/airbrake-go.CapturePanic", "airbrake-go.CapturePanic"},
+		{"github.com/Shopify/reportifydb.(*Partition).view", "reportifydb.(*Partition).view"},
+		{"github.com/Shopify/reportifydb.*Handler.AdminQuery·fm", "reportifydb.*Handler.AdminQuery.fm"},
+	} {
+		if result := shorten(sample.in); result != sample.out {
+			t.Fatalf("expected: %s got: %s", sample.out, result)
+		}
+	}
+}
+
+func TestLocate(t *testing.T) {
+	RootPackage = "github.com/Shopify/reportifydb"
+	for _, sample := range []struct{ in, out string }{
+		{"/home/vagrant/src/go/src/github.com/Shopify/reportifydb/shopifyql/executor.go",
+			"[PROJECT_ROOT]/shopifyql/executor.go",
+		},
+		{"/home/vagrant/src/go/src/github.com/Shopify/reportifydb/handler_admin.go",
+			"[PROJECT_ROOT]/handler_admin.go",
+		},
+		{"/home/vagrant/src/go/src/github.com/tobi/airbrake-go/airbrake.go",
+			"/home/vagrant/src/go/src/github.com/tobi/airbrake-go/airbrake.go",
+		},
+		{"/usr/local/go/src/pkg/net/http/server.go",
+			"/usr/local/go/src/pkg/net/http/server.go",
+		},
+	} {
+		if result := locate(sample.in); result != sample.out {
+			t.Fatalf("expected: %s got: %s", sample.out, result)
+		}
+	}
+}
+
 // Make sure we match https://help.airbrake.io/kb/api-2/notifier-api-version-23
 func TestTemplateV2(t *testing.T) {
 	var p map[string]interface{}

--- a/airbrake_test.go
+++ b/airbrake_test.go
@@ -151,9 +151,9 @@ func TestTemplateV2(t *testing.T) {
     <cgi-data>
       <var key="?q">SHOW x BY y FROM z</var>
       <var key="?t">xxx</var>
-      <var key="Host">Zulu</var>
-      <var key="Method">GET</var>
-      <var key="Protocol">HTTP/1.1</var>
+      <var key="HTTP_HOST">Zulu</var>
+      <var key="REQUEST_METHOD">GET</var>
+      <var key="REQUEST_PROTOCOL">HTTP/1.1</var>
     </cgi-data>
   </request>` {
 		t.Fatal(chunk)


### PR DESCRIPTION
The way the function names were processed wasn't quite right as can be seen in this [backtrace](https://exceptions.shopify.com/apps/54abfdafb74f33389b0002d7/errs/54aeb463b74f335135002b8f) where you can see function names like `com/Shopify/reportifydb.(*Partition).view` instead of the intended `(*Partition).view`. This PR fixes that by excluding everything up to last slash instead.

Backtrace hyperlinking is enabled through two new (optional) configuration parameters, RootPackage and AppVersion, details are in the associated comments.

I added some unit test for both issues and again tested this live with custom reportifydb builds, the results can be seen [here](https://exceptions.shopify.com/apps/54abfdafb74f33389b0002d7/errs/54aedfeeb74f331969004c50/notices/54aee47eb74f33775f00199b).

As I was researching how the hyperlinking works I also noticed that errbit processes some of the keys in the Environment tab (e.g. user agent) and expects them to be capitalized, underscored and prefixed with HTTP_, that's fixed here as well.

@benbjohnson, @burke, @snormore :eyes: please.

/cc @tobi
