### PR TITLE
Make empty params element have no text

### DIFF
--- a/airbrake.go
+++ b/airbrake.go
@@ -266,11 +266,9 @@ const source = `<?xml version="1.0" encoding="UTF-8"?>
     <component>{{ .Component }}</component>
     <action>{{ .Action }}</action>
     <params>{{ range $key, $value := .Form }}
-      <var key="{{ $key }}">{{ $value }}</var>{{ end }}
-    </params>
+      <var key="{{ $key }}">{{ $value }}</var>{{ end }}</params>
     <cgi-data>{{ range $key, $value := .Header }}
-      <var key="{{ $key }}">{{ $value }}</var>{{ end }}
-    </cgi-data>
+      <var key="{{ $key }}">{{ $value }}</var>{{ end }}</cgi-data>
   </request>{{ end }}
   <server-environment>
     <project-root>{{ html .Pwd }}</project-root>


### PR DESCRIPTION
It seems a newline in the element throws errbit off.

Fixes #4 

@arthurnn, @burke 

/cc @Shopify/analytics-stack 
